### PR TITLE
Use falsy value to use indexOf as a contain clause

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -129,11 +129,11 @@ namespace United {
             has(value: T | T[]) : boolean {
                 if(value instanceof Array) {
                     for(const k in value)
-                        if(this.__inner.indexOf(value[k]) == -1)
+                        if(!~this.__inner.indexOf(value[k]))
                             return false;
                     return true;
                 }
-                return this.__inner.indexOf(<T>value) != -1 ? true : false;
+                return ~this.__inner.indexOf(<T>value);
             }
             contains = this.has;
 


### PR DESCRIPTION
More informations [here](https://github.com/loverajoel/jstips/blob/gh-pages/_posts/en/2016-01-15-even-simpler-way-of-using-indexof-as-a-contains-clause.md) !
